### PR TITLE
ARROW-2812: [Ruby] Fix Arrow::Array#[] interface for Arrow::StructArray

### DIFF
--- a/lib/arrow/array.rb
+++ b/lib/arrow/array.rb
@@ -57,4 +57,10 @@ module Arrow
       self
     end
   end
+
+  class StructArray < Array
+    def [](i)
+      get_field(i)
+    end
+  end
 end

--- a/test/test-struct-array.rb
+++ b/test/test-struct-array.rb
@@ -1,0 +1,33 @@
+# Copyright 2017 Kouhei Sutou <kou@clear-code.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class StructArrayTest < Test::Unit::TestCase
+  test("#[]") do
+    type = Arrow::StructDataType.new([
+      Arrow::Field.new("field1", :boolean),
+      Arrow::Field.new("field2", :uint64),
+    ])
+    builder = Arrow::StructArrayBuilder.new(type)
+    builder.append
+    builder.get_field_builder(0).append(true)
+    builder.get_field_builder(1).append(1)
+    builder.append
+    builder.get_field_builder(0).append(false)
+    builder.get_field_builder(1).append(2)
+    array = builder.finish
+
+    assert_equal([true, 1, false, 2],
+                 [array[0][0], array[1][0], array[0][1], array[1][1]])
+  end
+end


### PR DESCRIPTION
`Arrow::StructArray` does not have `#get_value` method, and `Arrow::Array#[]` interface depends on `#get_value` method.

And so, `StructArray` cannot access internal columns via `#[]` interface.
 

Error message is following.
```
NoMethodError: undefined method `get_value' for #<Arrow::StructArray:0x0000000001859ac0>
```

This patch fixes it.